### PR TITLE
Add minimal benchmark.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,9 @@ halo2 = { git="https://github.com/zcash/halo2", branch="remove-metrics" }
 rand = "0.8"
 
 [dev-dependencies]
+criterion = "0.3"
 rand_xorshift = "0.3.0"
+
+[[bench]]
+name = "vdf"
+harness = false

--- a/benches/vdf.rs
+++ b/benches/vdf.rs
@@ -1,0 +1,44 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use halo2::arithmetic::FieldExt;
+use halo2::pasta::{pallas, vesta};
+use vdf::{PallasVDF, RoundValue, VanillaVDFProof, VestaVDF, VDF};
+
+fn bench_vdf<V: VDF<F>, F: FieldExt>(c: &mut Criterion, name: &str) {
+    let t = 10000;
+    let mut group = c.benchmark_group(format!("{}VDF-{}", name, t));
+
+    let x = RoundValue {
+        value: V::element(123),
+        round: F::zero(),
+    };
+
+    group.bench_function("eval_and_prove", |b| {
+        b.iter(|| {
+            VanillaVDFProof::<V, F>::eval_and_prove(x, t);
+        });
+    });
+
+    group.bench_function("verify", |b| {
+        let proof = VanillaVDFProof::<V, F>::eval_and_prove(x, t);
+
+        b.iter(|| {
+            proof.verify(x);
+        });
+    });
+    group.finish();
+}
+
+fn bench_pallas(c: &mut Criterion) {
+    bench_vdf::<PallasVDF, pallas::Scalar>(c, "Pallas")
+}
+fn bench_vesta(c: &mut Criterion) {
+    bench_vdf::<VestaVDF, vesta::Scalar>(c, "Vesta")
+}
+
+criterion_group! {
+    name = vdf;
+    config = Criterion::default().sample_size(60);
+    targets = bench_pallas, bench_vesta
+}
+
+criterion_main!(vdf);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,8 @@ pub type TargetVDF = PallasVDF;
 
 #[derive(std::cmp::PartialEq, Debug, Clone, Copy)]
 pub struct RoundValue<T> {
-    value: T,
-    round: T,
+    pub value: T,
+    pub round: T,
 }
 
 pub trait VDF<F>: Debug


### PR DESCRIPTION
This PR adds a minimal benchmark which times both `PallasVDF` and `VestaVDF` for both evaluation and verification.

Results below were obtained on an AMD Ryzen Threadripper 3970x.

UPDATE: The benchmarks in the original description were *not* from the claimed machine, so I am replacing them with new ones, which are — for the sake of future consistency.]

Both functions show about a factor of ~20~ 25 difference in time between evaluation and naive verification.

```

➜  vdf git:(main) ✗ cargo bench
    Finished bench [optimized] target(s) in 0.03s
     Running target/release/deps/vdf-8982510198d662d7

running 4 tests
test tests::test_eval ... ignored
test tests::test_exponents ... ignored
test tests::test_steps ... ignored
test tests::test_vanilla_proof ... ignored

test result: ok. 0 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running target/release/deps/vdf-5add7ba5ee3e264c
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
PallasVDF-10000/eval_and_prove
                        time:   [70.928 ms 70.936 ms 70.944 ms]
                        change: [-0.8854% -0.8687% -0.8515%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 60 measurements (6.67%)
  2 (3.33%) low severe
  2 (3.33%) low mild
Benchmarking PallasVDF-10000/verify: Warming up for 3.0000 s
Warning: Unable to complete 60 samples in 5.0s. You may wish to increase target time to 5.2s, enable flat sampling, or reduce sample count to 40.
PallasVDF-10000/verify  time:   [2.8401 ms 2.8578 ms 2.8834 ms]
                        change: [-3.0314% +0.4160% +3.0970%] (p = 0.82 > 0.05)
                        No change in performance detected.
Found 10 outliers among 60 measurements (16.67%)
  1 (1.67%) low mild
  3 (5.00%) high mild
  6 (10.00%) high severe

VestaVDF-10000/eval_and_prove
                        time:   [71.643 ms 71.652 ms 71.660 ms]
                        change: [-1.1693% -1.1409% -1.1121%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 60 measurements (1.67%)
  1 (1.67%) low mild
Benchmarking VestaVDF-10000/verify: Warming up for 3.0000 s
Warning: Unable to complete 60 samples in 5.0s. You may wish to increase target time to 6.3s, enable flat sampling, or reduce sample count to 30.
VestaVDF-10000/verify   time:   [3.4150 ms 3.4173 ms 3.4196 ms]
                        change: [-0.2710% -0.1914% -0.1122%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 60 measurements (11.67%)
  6 (10.00%) high mild
  1 (1.67%) high severe

```