### PR TITLE
Rename to RaguVDF and specialize operations.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 ff = "0.8"
-halo2 = { git="https://github.com/zcash/halo2", branch="remove-metrics" }
+halo2 = { git="https://github.com/zcash/halo2", branch="main" }
 rand = "0.8"
 
 [dev-dependencies]

--- a/benches/vdf.rs
+++ b/benches/vdf.rs
@@ -1,9 +1,9 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use halo2::arithmetic::FieldExt;
 use halo2::pasta::{pallas, vesta};
-use vdf::{PallasVDF, RoundValue, VanillaVDFProof, VestaVDF, VDF};
+use vdf::{PallasVDF, RaguVDF, RoundValue, VanillaVDFProof, VestaVDF};
 
-fn bench_vdf<V: VDF<F>, F: FieldExt>(c: &mut Criterion, name: &str) {
+fn bench_vdf<V: RaguVDF<F>, F: FieldExt>(c: &mut Criterion, name: &str) {
     let t = 10000;
     let mut group = c.benchmark_group(format!("{}VDF-{}", name, t));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,18 +11,109 @@ pub const TEST_SEED: [u8; 16] = [42; 16];
 /// Modulus is that of `Fq`, which is the base field of `Vesta` and scalar field of `Pallas`.
 #[derive(Debug)]
 pub struct PallasVDF {}
-impl VDF<pallas::Scalar> for PallasVDF {
+impl RaguVDF<pallas::Scalar> for PallasVDF {
     fn element(n: u64) -> pallas::Scalar {
         pallas::Scalar::from(n)
+    }
+
+    /// Pallas' inverse_exponent is 5, so we can hardcode this.
+    fn inverse_step(x: pallas::Scalar) -> pallas::Scalar {
+        x.mul(&x.square().square())
+    }
+
+    fn forward_step(x: pallas::Scalar) -> pallas::Scalar {
+        let sqr = |x: pallas::Scalar, i: u32| (0..i).fold(x, |x, _| x.square());
+
+        let mul = |x: pallas::Scalar, y| x.mul(y);
+        let sqr_mul = |x, n, y: pallas::Scalar| y.mul(&sqr(x, n));
+
+        let q1 = x;
+        let q10 = sqr(q1, 1);
+        let q11 = mul(q10, &q1);
+        let q101 = mul(q10, &q11);
+        let q110 = sqr(q11, 1);
+        let q111 = mul(q110, &q1);
+        let q1001 = mul(q111, &q10);
+        let q1111 = mul(q1001, &q110);
+        let qr2 = sqr_mul(q110, 3, q11);
+        let qr4 = sqr_mul(qr2, 8, qr2);
+        let qr8 = sqr_mul(qr4, 16, qr4);
+        let qr16 = sqr_mul(qr8, 32, qr8);
+        let qr32 = sqr_mul(qr16, 64, qr16);
+        let qr32a = sqr_mul(qr32, 5, q1001);
+        let qr32b = sqr_mul(qr32a, 8, q111);
+        let qr32c = sqr_mul(qr32b, 4, q1);
+        let qr32d = sqr_mul(qr32c, 2, qr4);
+        let qr32e = sqr_mul(qr32d, 7, q11);
+        let qr32f = sqr_mul(qr32e, 6, q1001);
+        let qr32g = sqr_mul(qr32f, 3, q101);
+        let qr32h = sqr_mul(qr32g, 7, q101);
+        let qr32i = sqr_mul(qr32h, 7, q111);
+        let qr32j = sqr_mul(qr32i, 4, q111);
+        let qr32k = sqr_mul(qr32j, 5, q1001);
+        let qr32l = sqr_mul(qr32k, 5, q101);
+        let qr32m = sqr_mul(qr32l, 3, q11);
+        let qr32n = sqr_mul(qr32m, 4, q101);
+        let qr32o = sqr_mul(qr32n, 3, q101);
+        let qr32p = sqr_mul(qr32o, 6, q1111);
+        let qr32q = sqr_mul(qr32p, 4, q1001);
+        let qr32r = sqr_mul(qr32q, 6, q101);
+        let qr32s = sqr_mul(qr32r, 37, qr8);
+        let qr32t = sqr_mul(qr32s, 2, q1);
+        qr32t
     }
 }
 
 /// Modulus is that of `Fp`, which is the base field of `Pallas and scalar field of Vesta.
 #[derive(Debug)]
 pub struct VestaVDF {}
-impl VDF<vesta::Scalar> for VestaVDF {
+impl RaguVDF<vesta::Scalar> for VestaVDF {
     fn element(n: u64) -> vesta::Scalar {
         vesta::Scalar::from(n)
+    }
+    /// Vesta's inverse_exponent is 5, so we can hardcode this.
+    fn inverse_step(x: vesta::Scalar) -> vesta::Scalar {
+        x.mul(&x.square().square())
+    }
+    fn forward_step(x: vesta::Scalar) -> vesta::Scalar {
+        let sqr = |x: vesta::Scalar, i: u32| (0..i).fold(x, |x, _| x.square());
+
+        let mul = |x: vesta::Scalar, y| x.mul(y);
+        let sqr_mul = |x, n, y: vesta::Scalar| y.mul(&sqr(x, n));
+
+        let p1 = x;
+        let p10 = sqr(p1, 1);
+        let p11 = mul(p10, &p1);
+        let p101 = mul(p10, &p11);
+        let p110 = sqr(p11, 1);
+        let p111 = mul(p110, &p1);
+        let p1001 = mul(p111, &p10);
+        let p1111 = mul(p1001, &p110);
+        let pr2 = sqr_mul(p110, 3, p11);
+        let pr4 = sqr_mul(pr2, 8, pr2);
+        let pr8 = sqr_mul(pr4, 16, pr4);
+        let pr16 = sqr_mul(pr8, 32, pr8);
+        let pr32 = sqr_mul(pr16, 64, pr16);
+        let pr32a = sqr_mul(pr32, 5, p1001);
+        let pr32b = sqr_mul(pr32a, 8, p111);
+        let pr32c = sqr_mul(pr32b, 4, p1);
+        let pr32d = sqr_mul(pr32c, 2, pr4);
+        let pr32e = sqr_mul(pr32d, 7, p11);
+        let pr32f = sqr_mul(pr32e, 6, p1001);
+        let pr32g = sqr_mul(pr32f, 3, p101);
+        let pr32h = sqr_mul(pr32g, 5, p1);
+        let pr32i = sqr_mul(pr32h, 7, p101);
+        let pr32j = sqr_mul(pr32i, 4, p11);
+        let pr32k = sqr_mul(pr32j, 8, p111);
+        let pr32l = sqr_mul(pr32k, 4, p1);
+        let pr32m = sqr_mul(pr32l, 4, p111);
+        let pr32n = sqr_mul(pr32m, 9, p1111);
+        let pr32o = sqr_mul(pr32n, 8, p1111);
+        let pr32p = sqr_mul(pr32o, 6, p1111);
+        let pr32q = sqr_mul(pr32p, 2, p11);
+        let pr32r = sqr_mul(pr32q, 34, pr8);
+        let pr32s = sqr_mul(pr32r, 2, p1);
+        pr32s
     }
 }
 
@@ -35,7 +126,7 @@ pub struct RoundValue<T> {
     pub round: T,
 }
 
-pub trait VDF<F>: Debug
+pub trait RaguVDF<F>: Debug
 where
     F: FieldExt,
 {
@@ -63,7 +154,7 @@ where
         x.pow_vartime([Self::inverse_exponent(), 0, 0, 0])
     }
 
-    /// One round in the slow/forward direction.
+    /// one round in the slow/forward direction.
     fn round(x: RoundValue<F>) -> RoundValue<F> {
         RoundValue {
             // Increment the value by the round number so problematic values
@@ -104,13 +195,13 @@ where
 }
 
 #[derive(Debug)]
-pub struct VanillaVDFProof<V: VDF<F> + Debug, F: FieldExt> {
+pub struct VanillaVDFProof<V: RaguVDF<F> + Debug, F: FieldExt> {
     result: RoundValue<F>,
     t: u64,
     _v: PhantomData<V>,
 }
 
-impl<V: VDF<F>, F: FieldExt> VanillaVDFProof<V, F> {
+impl<V: RaguVDF<F>, F: FieldExt> VanillaVDFProof<V, F> {
     pub fn eval_and_prove(x: RoundValue<F>, t: u64) -> Self {
         let result = V::eval(x, t);
         Self {
@@ -153,7 +244,7 @@ mod tests {
         test_exponents_aux::<VestaVDF, vesta::Scalar>();
     }
 
-    fn test_exponents_aux<V: VDF<F>, F: FieldExt>() {
+    fn test_exponents_aux<V: RaguVDF<F>, F: FieldExt>() {
         assert_eq!(V::inverse_exponent(), 5);
         assert_eq!(V::inverse_exponent(), 5);
     }
@@ -164,7 +255,7 @@ mod tests {
         test_steps_aux::<VestaVDF, vesta::Scalar>();
     }
 
-    fn test_steps_aux<V: VDF<F>, F: FieldExt>() {
+    fn test_steps_aux<V: RaguVDF<F>, F: FieldExt>() {
         let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
         for _ in 0..100 {
@@ -182,7 +273,7 @@ mod tests {
         test_eval_aux::<VestaVDF, vesta::Scalar>();
     }
 
-    fn test_eval_aux<V: VDF<F>, F: FieldExt>() {
+    fn test_eval_aux<V: RaguVDF<F>, F: FieldExt>() {
         let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
         for _ in 0..10 {
@@ -204,7 +295,7 @@ mod tests {
         test_vanilla_proof_aux::<VestaVDF, vesta::Scalar>();
     }
 
-    fn test_vanilla_proof_aux<V: VDF<F>, F: FieldExt>() {
+    fn test_vanilla_proof_aux<V: RaguVDF<F>, F: FieldExt>() {
         let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
         let value = F::random(&mut rng);


### PR DESCRIPTION
Rename `VDF` to `RaguVDF`: 'Slow-cooked pasta sauce, with instantly-verifiable flavor.'

Use hand-assembled addition chains for forward (https://github.com/zcash/zcash/issues/4883#issuecomment-743785323) and inverse steps.

New benchmarks show naive verification to be 95x faster than evaluation for `VestaVDF` and 99x faster for `PallasVDF` — which is approximately as expected.

Verification is ~4x faster than before, but for some reason (on the benchmark machine), evaluation is a bit slower. NOTE: evaluation was about 15% faster on the first machine I tested on. Since I would expect it to be faster, it's unclear what's happening on the benchmark machine.

```
➜  vdf git:(optimize) ✗ cargo bench
   Compiling vdf v0.1.0 (/home/porcuquine/dev/vdf)
    Finished bench [optimized] target(s) in 1.94s
     Running target/release/deps/vdf-8982510198d662d7

running 4 tests
test tests::test_eval ... ignored
test tests::test_exponents ... ignored
test tests::test_steps ... ignored
test tests::test_vanilla_proof ... ignored

test result: ok. 0 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running target/release/deps/vdf-5add7ba5ee3e264c
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
PallasVDF-10000/eval_and_prove
                        time:   [74.294 ms 74.317 ms 74.340 ms]
                        change: [+4.7342% +4.7666% +4.8026%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 60 measurements (5.00%)
  2 (3.33%) low mild
  1 (1.67%) high mild
PallasVDF-10000/verify  time:   [748.70 us 748.82 us 748.94 us]
                        change: [-73.939% -73.783% -73.663%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 60 measurements (5.00%)
  3 (5.00%) low mild

VestaVDF-10000/eval_and_prove
                        time:   [72.867 ms 72.892 ms 72.915 ms]
                        change: [+1.6916% +1.7303% +1.7687%] (p = 0.00 < 0.05)
                        Performance has regressed.
VestaVDF-10000/verify   time:   [762.08 us 762.18 us 762.30 us]
                        change: [-77.699% -77.688% -77.677%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 60 measurements (6.67%)
  3 (5.00%) high mild
  1 (1.67%) high severe

```