### PR TITLE
Implement and benchmark many evaluation modes.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,6 @@ parameters:
     type: string
     default: "nightly-2021-03-18"
 
-orbs:
-  codecov: codecov/codecov@1
-
 executors:
   default:
     docker:
@@ -113,7 +110,7 @@ jobs:
       - set-env-path
       - run:
           name: Run cargo clippy
-          command: cargo clippy --all-targets --all-features --workspace -- -D warnings
+          command: cargo +$(cat rust-toolchain) clippy --all-targets --all-features --workspace
 
   test:
     executor: default
@@ -161,9 +158,6 @@ jobs:
             # Only export the coverage of this project, we don't care about coverage of
             # dependencies
             llvm-cov export --ignore-filename-regex=".cargo|.rustup" --format=lcov -instr-profile=default.profdata --object=${OBJECT_FILES} > lcov.info
-      # Codecov automatically merges the reports in case there are several ones uploaded
-      - codecov/upload:
-          file: lcov.info
 
 workflows:
   version: 2.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["porcuquine <porcuquine@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+crossbeam = "0.8"
 ff = "0.8"
 halo2 = { git="https://github.com/zcash/halo2", branch = "main" }
 rand = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,33 +1,504 @@
 use core::fmt::Debug;
-use std::marker::PhantomData;
-
 use halo2::arithmetic::FieldExt;
 use halo2::pasta::{pallas, vesta};
+use std::cell::UnsafeCell;
+use std::marker::PhantomData;
+use std::mem::transmute;
+use std::slice;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 pub const TEST_SEED: [u8; 16] = [42; 16];
 
 // Question: Should the naming of `PallasVDF` and `VestaVDF` be reversed?
 
+#[derive(Debug, Clone, Copy)]
+pub enum EvalMode {
+    LTRSequential,
+    LTRAddChainSequential,
+    RTLSequential,
+    RTLParallel,
+    RTLAddChainSequential,
+    RTLAddChainParallel,
+}
+
+impl EvalMode {
+    pub fn all() -> Vec<EvalMode> {
+        vec![
+            Self::LTRSequential,
+            Self::LTRAddChainSequential,
+            Self::RTLSequential,
+            Self::RTLParallel,
+            Self::RTLAddChainSequential,
+            Self::RTLAddChainParallel,
+        ]
+    }
+}
+
+#[derive(Debug)]
+struct Sq(Arc<UnsafeCell<Box<[[u64; 4]]>>>);
+unsafe impl Send for Sq {}
+unsafe impl Sync for Sq {}
+
 /// Modulus is that of `Fq`, which is the base field of `Vesta` and scalar field of `Pallas`.
 #[derive(Debug)]
-pub struct PallasVDF {}
-impl VDF<pallas::Scalar> for PallasVDF {
+pub struct PallasVDF {
+    eval_mode: EvalMode,
+}
+
+impl RaguVDF<pallas::Scalar> for PallasVDF {
+    fn new_with_mode(eval_mode: EvalMode) -> Self {
+        PallasVDF { eval_mode }
+    }
+
+    // To bench with this on 3970x:
+    // RUSTFLAG="-C target-cpu=native -g" taskset -c 0,40 cargo bench
+    fn eval(&mut self, x: RoundValue<pallas::Scalar>, t: u64) -> RoundValue<pallas::Scalar> {
+        match self.eval_mode {
+            EvalMode::LTRSequential
+            | EvalMode::LTRAddChainSequential
+            | EvalMode::RTLAddChainSequential
+            | EvalMode::RTLSequential => self.simple_eval(x, t),
+            EvalMode::RTLAddChainParallel => self.eval_rtl_addition_chain(x, t),
+            EvalMode::RTLParallel => self.eval_rtl(x, t),
+        }
+    }
+
     fn element(n: u64) -> pallas::Scalar {
         pallas::Scalar::from(n)
+    }
+
+    /// Pallas' inverse_exponent is 5, so we can hardcode this.
+    fn inverse_step(x: pallas::Scalar) -> pallas::Scalar {
+        x.mul(&x.square().square())
+    }
+
+    fn forward_step(&mut self, x: pallas::Scalar) -> pallas::Scalar {
+        match self.eval_mode {
+            EvalMode::LTRSequential => self.forward_step_ltr_sequential(x),
+            EvalMode::RTLSequential => self.forward_step_rtl_sequential(x),
+            EvalMode::RTLAddChainSequential => self.forward_step_sequential_rtl_addition_chain(x),
+            EvalMode::LTRAddChainSequential => self.forward_step_ltr_addition_chain(x),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl PallasVDF {
+    /// Number of bits in exponent.
+    fn bit_count() -> usize {
+        254
+    }
+
+    // To bench with this on 3970x:
+    // RUSTFLAG="-C target-cpu=native -g" taskset -c 0,40 cargo bench
+    fn eval_rtl(&mut self, x: RoundValue<pallas::Scalar>, t: u64) -> RoundValue<pallas::Scalar> {
+        let bit_count = Self::bit_count();
+        let squares1 = Arc::new(UnsafeCell::new(vec![[0u64; 4]; 254].into_boxed_slice()));
+        let sq = Sq(squares1);
+        let ready = Arc::new(AtomicUsize::new(1)); // Importantly, not zero.
+        let ready_clone = Arc::clone(&ready);
+
+        crossbeam::scope(|s| {
+            s.spawn(|_| {
+                let squares = unsafe {
+                    transmute::<&mut [[u64; 4]], &mut [pallas::Scalar]>(slice::from_raw_parts_mut(
+                        (*sq.0.get()).as_mut_ptr(),
+                        bit_count,
+                    ))
+                };
+
+                macro_rules! store {
+                    ($index:ident, $val:ident) => {
+                        squares[$index] = $val;
+                        ready.store($index, Ordering::SeqCst)
+                    };
+                };
+
+                for _ in 0..t {
+                    while ready.load(Ordering::SeqCst) != 0 {}
+
+                    let mut next_square = squares[0];
+
+                    for i in 0..Self::bit_count() {
+                        if i > 0 {
+                            next_square = next_square.square();
+                        };
+
+                        store!(i, next_square);
+                    }
+                }
+            });
+            (0..t).fold(x, |acc, _| self.round_with_squares(acc, &sq, &ready_clone))
+        })
+        .unwrap()
+    }
+
+    // To bench with this on 3970x:
+    // RUSTFLAG="-C target-cpu=native -g" taskset -c 0,40 cargo bench
+    fn eval_rtl_addition_chain(
+        &mut self,
+        x: RoundValue<pallas::Scalar>,
+        t: u64,
+    ) -> RoundValue<pallas::Scalar> {
+        let bit_count = Self::bit_count();
+        let squares1 = Arc::new(UnsafeCell::new(vec![[0u64; 4]; 254].into_boxed_slice()));
+        let sq = Sq(squares1);
+        let ready = Arc::new(AtomicUsize::new(1)); // Importantly, not zero.
+        let ready_clone = Arc::clone(&ready);
+
+        crossbeam::scope(|s| {
+            s.spawn(|_| {
+                let squares = unsafe {
+                    transmute::<&mut [[u64; 4]], &mut [pallas::Scalar]>(slice::from_raw_parts_mut(
+                        (*sq.0.get()).as_mut_ptr(),
+                        bit_count,
+                    ))
+                };
+
+                macro_rules! store {
+                    ($index:ident, $val:ident) => {
+                        squares[$index] = $val;
+                        ready.store($index, Ordering::SeqCst)
+                    };
+                };
+
+                for _ in 0..t {
+                    while ready.load(Ordering::SeqCst) != 0 {}
+
+                    let mut next_square = squares[0];
+
+                    let first_section_bit_count = 128;
+
+                    for i in 0..first_section_bit_count {
+                        if i > 0 {
+                            next_square = next_square.square();
+                        };
+
+                        store!(i, next_square);
+                    }
+
+                    let mut k = first_section_bit_count;
+
+                    next_square = {
+                        let mut x = next_square;
+
+                        x = x.mul(&x.square());
+                        x.mul(&x.square().square().square().square())
+                    };
+
+                    for j in 1..=(8 * 15 + 1) {
+                        next_square = next_square.square();
+
+                        if j % 8 == 1 {
+                            store!(k, next_square);
+                            k += 1;
+                        }
+                    }
+                }
+            });
+            (0..t).fold(x, |acc, _| self.round_with_squares(acc, &sq, &ready_clone))
+        })
+        .unwrap()
+    }
+
+    /// one round in the slow/forward direction.
+    #[inline]
+    fn round_with_squares(
+        &mut self,
+        x: RoundValue<pallas::Scalar>,
+        squares: &Sq,
+        ready: &Arc<AtomicUsize>,
+    ) -> RoundValue<pallas::Scalar> {
+        RoundValue {
+            // Increment the value by the round number so problematic values
+            // like 0 and 1 don't consistently defeat the asymmetry.
+            value: match self.eval_mode {
+                EvalMode::RTLParallel => self.forward_step_with_squares_naive_rtl(
+                    pallas::Scalar::add(&x.value, &x.round),
+                    squares,
+                    ready,
+                ),
+                EvalMode::RTLAddChainParallel => self.forward_step_with_squares(
+                    pallas::Scalar::add(&x.value, &x.round),
+                    squares,
+                    ready,
+                ),
+                _ => panic!("fell through in round_with_squares"),
+            },
+            // Increment the round.
+            round: pallas::Scalar::add(&x.round, &pallas::Scalar::one()),
+        }
+    }
+
+    #[inline]
+    fn forward_step_with_squares(
+        &mut self,
+        x: pallas::Scalar,
+        squares: &Sq,
+        ready: &Arc<AtomicUsize>,
+    ) -> pallas::Scalar {
+        let sq = squares.0.get();
+        unsafe { (**sq)[0] = transmute::<pallas::Scalar, [u64; 4]>(x) };
+
+        ready.store(0, Ordering::SeqCst);
+
+        let mut remaining = Self::exponent();
+        let mut acc = pallas::Scalar::one();
+
+        let bit_count = Self::bit_count();
+        let first_section_bit_count = 128;
+        let second_section_bit_count = bit_count - first_section_bit_count;
+        let n = first_section_bit_count + (second_section_bit_count / 8) + 1;
+
+        for next_index in 1..=n {
+            let current_index = next_index - 1;
+            let limb_index = current_index / 64;
+            let limb = remaining[limb_index];
+
+            let one = (limb & 1) == 1;
+            let in_second_section = next_index > first_section_bit_count;
+
+            if in_second_section || one {
+                while ready.load(Ordering::SeqCst)
+                    < if next_index > 1 {
+                        current_index
+                    } else {
+                        next_index
+                    }
+                {}
+
+                let squares =
+                    unsafe { transmute::<&[[u64; 4]], &[pallas::Scalar]>(&**(squares.0.get())) };
+                let elt = squares[current_index];
+                acc = acc.mul(&elt);
+            };
+
+            remaining[limb_index] = limb >> 1;
+        }
+        acc
+    }
+
+    #[inline]
+    fn forward_step_with_squares_naive_rtl(
+        &mut self,
+        x: pallas::Scalar,
+        squares: &Sq,
+        ready: &Arc<AtomicUsize>,
+    ) -> pallas::Scalar {
+        let sq = squares.0.get();
+        unsafe { (**sq)[0] = transmute::<pallas::Scalar, [u64; 4]>(x) };
+
+        ready.store(0, Ordering::SeqCst);
+
+        let mut remaining = Self::exponent();
+        let mut acc = pallas::Scalar::one();
+
+        let bit_count = Self::bit_count();
+        let first_section_bit_count = bit_count - 1;
+        let second_section_bit_count = bit_count - first_section_bit_count;
+        let n = first_section_bit_count + (second_section_bit_count / 8) + 1;
+
+        for next_index in 1..=n {
+            let current_index = next_index - 1;
+            let limb_index = current_index / 64;
+            let limb = remaining[limb_index];
+
+            let one = (limb & 1) == 1;
+            let in_second_section = next_index > first_section_bit_count;
+
+            if in_second_section || one {
+                while ready.load(Ordering::SeqCst)
+                    < if next_index > 1 {
+                        current_index
+                    } else {
+                        next_index
+                    }
+                {}
+
+                let squares =
+                    unsafe { transmute::<&[[u64; 4]], &[pallas::Scalar]>(&**(squares.0.get())) };
+                let elt = squares[current_index];
+                acc = acc.mul(&elt);
+            };
+
+            remaining[limb_index] = limb >> 1;
+        }
+        acc
+    }
+
+    fn forward_step_ltr_addition_chain(&mut self, x: pallas::Scalar) -> pallas::Scalar {
+        let sqr = |x: pallas::Scalar, i: u32| (0..i).fold(x, |x, _| x.square());
+
+        let mul = |x: pallas::Scalar, y| x.mul(y);
+        let sqr_mul = |x, n, y: pallas::Scalar| y.mul(&sqr(x, n));
+
+        let q1 = x;
+        let q10 = sqr(q1, 1);
+        let q11 = mul(q10, &q1);
+        let q101 = mul(q10, &q11);
+        let q110 = sqr(q11, 1);
+        let q111 = mul(q110, &q1);
+        let q1001 = mul(q111, &q10);
+        let q1111 = mul(q1001, &q110);
+        let qr2 = sqr_mul(q110, 3, q11);
+        let qr4 = sqr_mul(qr2, 8, qr2);
+        let qr8 = sqr_mul(qr4, 16, qr4);
+        let qr16 = sqr_mul(qr8, 32, qr8);
+        let qr32 = sqr_mul(qr16, 64, qr16);
+        let qr32a = sqr_mul(qr32, 5, q1001);
+        let qr32b = sqr_mul(qr32a, 8, q111);
+        let qr32c = sqr_mul(qr32b, 4, q1);
+        let qr32d = sqr_mul(qr32c, 2, qr4);
+        let qr32e = sqr_mul(qr32d, 7, q11);
+        let qr32f = sqr_mul(qr32e, 6, q1001);
+        let qr32g = sqr_mul(qr32f, 3, q101);
+        let qr32h = sqr_mul(qr32g, 7, q101);
+        let qr32i = sqr_mul(qr32h, 7, q111);
+        let qr32j = sqr_mul(qr32i, 4, q111);
+        let qr32k = sqr_mul(qr32j, 5, q1001);
+        let qr32l = sqr_mul(qr32k, 5, q101);
+        let qr32m = sqr_mul(qr32l, 3, q11);
+        let qr32n = sqr_mul(qr32m, 4, q101);
+        let qr32o = sqr_mul(qr32n, 3, q101);
+        let qr32p = sqr_mul(qr32o, 6, q1111);
+        let qr32q = sqr_mul(qr32p, 4, q1001);
+        let qr32r = sqr_mul(qr32q, 6, q101);
+        let qr32s = sqr_mul(qr32r, 37, qr8);
+        let qr32t = sqr_mul(qr32s, 2, q1);
+        qr32t
+    }
+
+    // Sequential RTL square-and-multiply.
+    fn forward_step_rtl_sequential(&mut self, x: pallas::Scalar) -> pallas::Scalar {
+        (0..254)
+            .scan(x, |state, _| {
+                let ret = *state;
+                *state = (*state).square();
+                Some(ret)
+            })
+            .fold(
+                (Self::exponent(), pallas::Scalar::one(), 0),
+                |(mut remaining, acc, count), elt| {
+                    let limb_index = count / 64;
+                    let limb = remaining[limb_index];
+
+                    let one = (limb & 1) == 1;
+                    let acc = if one { acc.mul(&elt) } else { acc };
+                    remaining[limb_index] = limb >> 1;
+
+                    (remaining, acc, count + 1)
+                },
+            )
+            .1
+    }
+
+    // Sequential RTL square-and-multiply with optimized addition chain.
+    fn forward_step_sequential_rtl_addition_chain(&mut self, x: pallas::Scalar) -> pallas::Scalar {
+        let first_section_bit_count = 128;
+        let acc = pallas::Scalar::one();
+
+        // First section is same as rtl without addition chain.
+        let (_, acc, _, square_acc) = (0..first_section_bit_count)
+            .scan(x, |state, _| {
+                let ret = *state;
+                *state = (*state).square();
+                Some(ret)
+            })
+            .fold(
+                (Self::exponent(), acc, 0, pallas::Scalar::zero()),
+                |(mut remaining, acc, count, _previous_elt), elt| {
+                    let limb_index = count / 64;
+                    let limb = remaining[limb_index];
+
+                    let one = (limb & 1) == 1;
+                    let acc = if one { acc.mul(&elt) } else { acc };
+                    remaining[limb_index] = limb >> 1;
+
+                    (remaining, acc, count + 1, elt)
+                },
+            );
+
+        let square_acc = square_acc.mul(&square_acc.square());
+        let square_acc = square_acc.mul(&square_acc.square().square().square().square());
+
+        let acc = (0..122)
+            .scan(square_acc, |state, _| {
+                *state = (*state).square();
+
+                Some(*state)
+            })
+            .fold((acc, 1), |(acc, count), elt| {
+                if count % 8 == 1 {
+                    (acc.mul(&elt), count + 1)
+                } else {
+                    (acc, count + 1)
+                }
+            })
+            .0;
+        acc
     }
 }
 
 /// Modulus is that of `Fp`, which is the base field of `Pallas and scalar field of Vesta.
 #[derive(Debug)]
 pub struct VestaVDF {}
-impl VDF<vesta::Scalar> for VestaVDF {
+impl RaguVDF<vesta::Scalar> for VestaVDF {
+    fn new_with_mode(_eval_mode: EvalMode) -> Self {
+        VestaVDF {}
+    }
+
     fn element(n: u64) -> vesta::Scalar {
         vesta::Scalar::from(n)
+    }
+    /// Vesta's inverse_exponent is 5, so we can hardcode this.
+    fn inverse_step(x: vesta::Scalar) -> vesta::Scalar {
+        x.mul(&x.square().square())
+    }
+    fn forward_step(&mut self, x: vesta::Scalar) -> vesta::Scalar {
+        let sqr = |x: vesta::Scalar, i: u32| (0..i).fold(x, |x, _| x.square());
+
+        let mul = |x: vesta::Scalar, y| x.mul(y);
+        let sqr_mul = |x, n, y: vesta::Scalar| y.mul(&sqr(x, n));
+
+        let p1 = x;
+        let p10 = sqr(p1, 1);
+        let p11 = mul(p10, &p1);
+        let p101 = mul(p10, &p11);
+        let p110 = sqr(p11, 1);
+        let p111 = mul(p110, &p1);
+        let p1001 = mul(p111, &p10);
+        let p1111 = mul(p1001, &p110);
+        let pr2 = sqr_mul(p110, 3, p11);
+        let pr4 = sqr_mul(pr2, 8, pr2);
+        let pr8 = sqr_mul(pr4, 16, pr4);
+        let pr16 = sqr_mul(pr8, 32, pr8);
+        let pr32 = sqr_mul(pr16, 64, pr16);
+        let pr32a = sqr_mul(pr32, 5, p1001);
+        let pr32b = sqr_mul(pr32a, 8, p111);
+        let pr32c = sqr_mul(pr32b, 4, p1);
+        let pr32d = sqr_mul(pr32c, 2, pr4);
+        let pr32e = sqr_mul(pr32d, 7, p11);
+        let pr32f = sqr_mul(pr32e, 6, p1001);
+        let pr32g = sqr_mul(pr32f, 3, p101);
+        let pr32h = sqr_mul(pr32g, 5, p1);
+        let pr32i = sqr_mul(pr32h, 7, p101);
+        let pr32j = sqr_mul(pr32i, 4, p11);
+        let pr32k = sqr_mul(pr32j, 8, p111);
+        let pr32l = sqr_mul(pr32k, 4, p1);
+        let pr32m = sqr_mul(pr32l, 4, p111);
+        let pr32n = sqr_mul(pr32m, 9, p1111);
+        let pr32o = sqr_mul(pr32n, 8, p1111);
+        let pr32p = sqr_mul(pr32o, 6, p1111);
+        let pr32q = sqr_mul(pr32p, 2, p11);
+        let pr32r = sqr_mul(pr32q, 34, pr8);
+        let pr32s = sqr_mul(pr32r, 2, p1);
+        pr32s
     }
 }
 
 // Question: Is this right, or is it the reverse? Which scalar fields' modulus do we want to target?
-pub type TargetVDF = PallasVDF;
+pub type TargetVDF<'a> = PallasVDF;
 
 #[derive(std::cmp::PartialEq, Debug, Clone, Copy)]
 pub struct RoundValue<T> {
@@ -35,10 +506,23 @@ pub struct RoundValue<T> {
     pub round: T,
 }
 
-pub trait VDF<F>: Debug
+pub trait RaguVDF<F>: Debug
 where
     F: FieldExt,
 {
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
+        Self::new_with_mode(Self::default_mode())
+    }
+
+    fn new_with_mode(eval_mode: EvalMode) -> Self;
+
+    fn default_mode() -> EvalMode {
+        EvalMode::LTRSequential
+    }
+
     #[inline]
     /// Exponent used to take a root in the 'slow' direction.
     fn exponent() -> [u64; 4] {
@@ -53,8 +537,14 @@ where
 
     #[inline]
     /// The building block of a round in the slow, 'forward' direction.
-    fn forward_step(x: F) -> F {
+    fn forward_step_ltr_sequential(&mut self, x: F) -> F {
         x.pow_vartime(Self::exponent())
+    }
+
+    #[inline]
+    /// The building block of a round in the slow, 'forward' direction.
+    fn forward_step(&mut self, x: F) -> F {
+        self.forward_step_ltr_sequential(x)
     }
 
     #[inline]
@@ -63,12 +553,12 @@ where
         x.pow_vartime([Self::inverse_exponent(), 0, 0, 0])
     }
 
-    /// One round in the slow/forward direction.
-    fn round(x: RoundValue<F>) -> RoundValue<F> {
+    /// one round in the slow/forward direction.
+    fn round(&mut self, x: RoundValue<F>) -> RoundValue<F> {
         RoundValue {
             // Increment the value by the round number so problematic values
             // like 0 and 1 don't consistently defeat the asymmetry.
-            value: Self::forward_step(F::add(x.value, x.round)),
+            value: self.forward_step(F::add(x.value, x.round)),
             // Increment the round.
             round: F::add(x.round, F::one()),
         }
@@ -84,8 +574,12 @@ where
 
     /// Evaluate input `x` with time/difficulty parameter, `t` in the
     /// slow/forward direction.
-    fn eval(x: RoundValue<F>, t: u64) -> RoundValue<F> {
-        (0..t).fold(x, |acc, _| Self::round(acc))
+    fn eval(&mut self, x: RoundValue<F>, t: u64) -> RoundValue<F> {
+        self.simple_eval(x, t)
+    }
+
+    fn simple_eval(&mut self, x: RoundValue<F>, t: u64) -> RoundValue<F> {
+        (0..t).fold(x, |acc, _| self.round(acc))
     }
 
     /// Invert evaluation of output `x` with time/difficulty parameter, `t` in
@@ -104,15 +598,26 @@ where
 }
 
 #[derive(Debug)]
-pub struct VanillaVDFProof<V: VDF<F> + Debug, F: FieldExt> {
+pub struct VanillaVDFProof<V: RaguVDF<F> + Debug, F: FieldExt> {
     result: RoundValue<F>,
     t: u64,
     _v: PhantomData<V>,
 }
 
-impl<V: VDF<F>, F: FieldExt> VanillaVDFProof<V, F> {
+impl<V: RaguVDF<F>, F: FieldExt> VanillaVDFProof<V, F> {
     pub fn eval_and_prove(x: RoundValue<F>, t: u64) -> Self {
-        let result = V::eval(x, t);
+        let mut vdf = V::new();
+        let result = vdf.eval(x, t);
+        Self {
+            result,
+            t,
+            _v: PhantomData::<V>,
+        }
+    }
+
+    pub fn eval_and_prove_with_mode(eval_mode: EvalMode, x: RoundValue<F>, t: u64) -> Self {
+        let mut vdf = V::new_with_mode(eval_mode);
+        let result = vdf.eval(x, t);
         Self {
             result,
             t,
@@ -153,7 +658,7 @@ mod tests {
         test_exponents_aux::<VestaVDF, vesta::Scalar>();
     }
 
-    fn test_exponents_aux<V: VDF<F>, F: FieldExt>() {
+    fn test_exponents_aux<V: RaguVDF<F>, F: FieldExt>() {
         assert_eq!(V::inverse_exponent(), 5);
         assert_eq!(V::inverse_exponent(), 5);
     }
@@ -164,12 +669,13 @@ mod tests {
         test_steps_aux::<VestaVDF, vesta::Scalar>();
     }
 
-    fn test_steps_aux<V: VDF<F>, F: FieldExt>() {
+    fn test_steps_aux<V: RaguVDF<F>, F: FieldExt>() {
         let mut rng = XorShiftRng::from_seed(TEST_SEED);
+        let mut vdf = V::new();
 
         for _ in 0..100 {
             let x = F::random(&mut rng);
-            let y = V::forward_step(x);
+            let y = vdf.forward_step(x);
             let z = V::inverse_step(y);
 
             assert_eq!(x, z);
@@ -178,19 +684,26 @@ mod tests {
 
     #[test]
     fn test_eval() {
+        println!("top");
         test_eval_aux::<PallasVDF, pallas::Scalar>();
-        test_eval_aux::<VestaVDF, vesta::Scalar>();
     }
 
-    fn test_eval_aux<V: VDF<F>, F: FieldExt>() {
-        let mut rng = XorShiftRng::from_seed(TEST_SEED);
+    fn test_eval_aux<V: RaguVDF<F>, F: FieldExt>() {
+        for mode in EvalMode::all().iter() {
+            test_eval_aux2::<V, F>(*mode)
+        }
+    }
 
-        for _ in 0..10 {
+    fn test_eval_aux2<V: RaguVDF<F>, F: FieldExt>(eval_mode: EvalMode) {
+        let mut rng = XorShiftRng::from_seed(TEST_SEED);
+        let mut vdf = V::new_with_mode(eval_mode);
+
+        for _ in 0..1 {
             let t = 10;
             let value = F::random(&mut rng);
             let round = F::random(&mut rng);
             let x = RoundValue { value, round };
-            let y = V::eval(x, t);
+            let y = vdf.eval(x, t);
             let z = V::inverse_eval(y, t);
 
             assert_eq!(x, z);
@@ -204,7 +717,7 @@ mod tests {
         test_vanilla_proof_aux::<VestaVDF, vesta::Scalar>();
     }
 
-    fn test_vanilla_proof_aux<V: VDF<F>, F: FieldExt>() {
+    fn test_vanilla_proof_aux<V: RaguVDF<F>, F: FieldExt>() {
         let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
         let value = F::random(&mut rng);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,48 @@
+use std::cell::UnsafeCell;
+use std::slice::{self};
+
+/// A slice type which can be shared between threads, but must be fully managed by the caller.
+/// Any synchronization must be ensured by the caller, which is why all access is `unsafe`.
+#[derive(Debug)]
+pub struct UnsafeSlice<'a, T> {
+    // holds the data to ensure lifetime correctness
+    data: UnsafeCell<&'a mut [T]>,
+    /// pointer to the data
+    ptr: *mut T,
+    /// Number of elements, not bytes.
+    len: usize,
+}
+
+unsafe impl<'a, T> Sync for UnsafeSlice<'a, T> {}
+unsafe impl<'a, T> Send for UnsafeSlice<'a, T> {}
+
+impl<'a, T> UnsafeSlice<'a, T> {
+    /// Takes mutable slice, to ensure that `UnsafeSlice` is the only user of this memory, until it gets dropped.
+    pub fn from_slice(source: &'a mut [T]) -> Self {
+        let len = source.len();
+        let ptr = source.as_mut_ptr();
+        let data = UnsafeCell::new(source);
+        Self { data, ptr, len }
+    }
+
+    /// Safety: The caller must ensure that there are no unsynchronized parallel access to the same regions.
+    #[inline]
+    pub unsafe fn as_mut_slice(&self) -> &'a mut [T] {
+        slice::from_raw_parts_mut(self.ptr, self.len)
+    }
+    /// Safety: The caller must ensure that there are no unsynchronized parallel access to the same regions.
+    #[inline]
+    pub unsafe fn as_slice(&self) -> &'a [T] {
+        slice::from_raw_parts(self.ptr, self.len)
+    }
+
+    #[inline]
+    pub unsafe fn get(&self, index: usize) -> &'a T {
+        &*self.ptr.add(index)
+    }
+
+    #[inline]
+    pub unsafe fn get_mut(&self, index: usize) -> &'a mut T {
+        &mut *self.ptr.add(index)
+    }
+}


### PR DESCRIPTION
This PR implements many different evaluation strategies (for `PallasVDF` only, for now) in order to understand performance tradeoffs. The various strategies are controlled by an `EvalMode` enum. Tests and benchmarks cover them all.

In particular, there are implementations of left-to-right, right-to-left square and multiply, both in 'naive' versions and using optimized addition chains (https://github.com/zcash/zcash/issues/4883#issuecomment-743785323, 
 https://github.com/zcash/pasta/commit/f744721899d03cb9888cf5944162eef933364aae).

Parallel versions are also implemented where appropriate. In order to perform reasonably, the parallel versions need to be run on the same physical core — and I accomplished this in benchmarks on a Threadripper 3970X, by invoking the command with `taskset -c 0,40`.

Somewhat surprisingly, on the benchmark machine, the initial, LTR square and multiply without optimized addition chain performs the best. Custom addition chain calculated sequentially does worse, but still beats the parallel version.

The parallel versions use a shared buffer and atomics to minimize thread synchronization overhead.

It is not yet clear why performance is as it is. Nevertheless, this work provides a starting point for further optimization and measurement — as well as a framework for managing multiple strategies, with working and tested implementations of each.

```
➜  vdf git:(parallel-exp) RUSTFLAG="-C target-cpu=native -g" taskset -c 0,40 cargo bench
    Finished bench [optimized] target(s) in 0.03s
     Running target/release/deps/vdf-9494b02731be981c

running 4 tests
test tests::test_eval ... ignored
test tests::test_exponents ... ignored
test tests::test_steps ... ignored
test tests::test_vanilla_proof ... ignored

test result: ok. 0 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running target/release/deps/vdf-7d55662c04d19e74
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
Benchmarking PallasVDF-eval-LTRSequential-10000/eval_and_prove: Collecting 60 samples in estimated 8.5600 s (120 i                                                                                                                  PallasVDF-eval-LTRSequential-10000/eval_and_prove
                        time:   [71.381 ms 71.407 ms 71.431 ms]
                        change: [+0.0514% +0.0888% +0.1267%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking PallasVDF-eval-LTRAddChainSequential-10000/eval_and_prove: Collecting 60 samples in estimated 8.9206                                                                                                                   PallasVDF-eval-LTRAddChainSequential-10000/eval_and_prove
                        time:   [74.349 ms 74.356 ms 74.363 ms]
                        change: [+0.0886% +0.1204% +0.1518%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking PallasVDF-eval-RTLSequential-10000/eval_and_prove: Warming up for 3.0000 s
Warning: Unable to complete 60 samples in 5.0s. You may wish to increase target time to 5.3s, or reduce sample count to 50.
Benchmarking PallasVDF-eval-RTLSequential-10000/eval_and_prove: Collecting 60 samples in estimated 5.3452 s (60 it                                                                                                                  PallasVDF-eval-RTLSequential-10000/eval_and_prove
                        time:   [89.141 ms 89.202 ms 89.269 ms]
                        change: [-0.4493% -0.3437% -0.2344%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 60 measurements (1.67%)
  1 (1.67%) high mild

Benchmarking PallasVDF-eval-RTLParallel-10000/eval_and_prove: Warming up for 3.0000 s
Warning: Unable to complete 60 samples in 5.0s. You may wish to increase target time to 5.7s, or reduce sample count to 50.
Benchmarking PallasVDF-eval-RTLParallel-10000/eval_and_prove: Collecting 60 samples in estimated 5.6785 s (60 iter                                                                                                                  PallasVDF-eval-RTLParallel-10000/eval_and_prove
                        time:   [94.641 ms 94.676 ms 94.714 ms]
                        change: [-0.1988% -0.1423% -0.0861%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 60 measurements (11.67%)
  5 (8.33%) high mild
  2 (3.33%) high severe

Benchmarking PallasVDF-eval-RTLAddChainSequential-10000/eval_and_prove: Collecting 60 samples in estimated 9.8542                                                                                                                   PallasVDF-eval-RTLAddChainSequential-10000/eval_and_prove
                        time:   [82.083 ms 82.096 ms 82.110 ms]
                        change: [-0.2623% -0.2347% -0.2052%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 60 measurements (13.33%)
  2 (3.33%) low severe
  1 (1.67%) low mild
  2 (3.33%) high mild
  3 (5.00%) high severe

Benchmarking PallasVDF-eval-RTLAddChainParallel-10000/eval_and_prove: Warming up for 3.0000 s
Warning: Unable to complete 60 samples in 5.0s. You may wish to increase target time to 5.3s, or reduce sample count to 50.
Benchmarking PallasVDF-eval-RTLAddChainParallel-10000/eval_and_prove: Collecting 60 samples in estimated 5.2968 s                                                                                                                   PallasVDF-eval-RTLAddChainParallel-10000/eval_and_prove
                        time:   [88.228 ms 88.256 ms 88.287 ms]
                        change: [-0.3584% -0.3153% -0.2727%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 60 measurements (6.67%)
  2 (3.33%) high mild
  2 (3.33%) high severe

PallasVDF-verify-10000/verify
                        time:   [754.13 us 755.43 us 756.82 us]
                        change: [-0.6475% -0.4702% -0.3177%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking VestaVDF-eval-LTRSequential-10000/eval_and_prove: Collecting 60 samples in estimated 8.8604 s (120 it                                                                                                                  VestaVDF-eval-LTRSequential-10000/eval_and_prove
                        time:   [73.880 ms 73.892 ms 73.904 ms]
                        change: [-0.6418% -0.6165% -0.5903%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 60 measurements (3.33%)
  1 (1.67%) low mild
  1 (1.67%) high mild

VestaVDF-verify-10000/verify
                        time:   [754.03 us 754.15 us 754.28 us]
                        change: [+0.2624% +0.2957% +0.3316%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 60 measurements (1.67%)
  1 (1.67%) high severe
```