### PR TITLE
chore: make clippy fail on warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
       - set-env-path
       - run:
           name: Run cargo clippy
-          command: cargo +$(cat rust-toolchain) clippy --all-targets --all-features --workspace
+          command: cargo +$(cat rust-toolchain) clippy --all-targets --all-features --workspace -- -D warnings
 
   test:
     executor: default


### PR DESCRIPTION
On CI Clippy should indicate if there are any issues. This check was disabled in
https://github.com/protocol/vdf/pull/6/files#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L116
and is now re-enabled again.