### PR TITLE
Update Nova and Pasta Curves

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,9 @@ crossbeam = "0.8"
 ff = "0.11.0"
 merlin = "2.0.0"
 nova = { package = "nova-snark", version = "0.4.0" }
+once_cell = "1.9.0"
 pairing = "0.21"
-pasta_curves = "0.2.1"
+pasta_curves = "0.3.0"
 rand = "0.8"
 subtle = "2.3"
 
@@ -27,3 +28,6 @@ harness = false
 [[bench]]
 name = "nova"
 harness = false
+
+[patch.crates-io]
+nova = { git = "https://github.com/porcuquine/nova", branch = "update-pasta", package = "nova-snark" }

--- a/src/minroot.rs
+++ b/src/minroot.rs
@@ -70,6 +70,21 @@ impl MinRootVDF<pallas::Scalar> for PallasVDF {
         pallas::Scalar::from(n)
     }
 
+    #[inline]
+    fn exponent() -> [u64; 4] {
+        [
+            0xd69f2280cccccccd,
+            0x4e9ee0c9a143ba4a,
+            0x3333333333333333,
+            0x3333333333333333,
+        ]
+    }
+
+    #[inline]
+    fn inverse_exponent() -> u64 {
+        5
+    }
+
     /// Pallas' inverse_exponent is 5, so we can hardcode this.
     fn inverse_step(x: pallas::Scalar) -> pallas::Scalar {
         x.mul(&x.square().square())
@@ -458,6 +473,22 @@ impl MinRootVDF<vesta::Scalar> for VestaVDF {
     fn element(n: u64) -> vesta::Scalar {
         vesta::Scalar::from(n)
     }
+
+    #[inline]
+    fn exponent() -> [u64; 4] {
+        [
+            0xe0f0f3f0cccccccd,
+            0x4e9ee0c9a10a60e2,
+            0x3333333333333333,
+            0x3333333333333333,
+        ]
+    }
+
+    #[inline]
+    fn inverse_exponent() -> u64 {
+        5
+    }
+
     /// Vesta's inverse_exponent is 5, so we can hardcode this.
     fn inverse_step(x: vesta::Scalar) -> vesta::Scalar {
         x.mul(&x.square().square())
@@ -530,17 +561,11 @@ where
         EvalMode::LTRSequential
     }
 
-    #[inline]
     /// Exponent used to take a root in the 'slow' direction.
-    fn exponent() -> [u64; 4] {
-        F::RESCUE_INVALPHA
-    }
+    fn exponent() -> [u64; 4];
 
-    #[inline]
     /// Exponent used in the 'fast' direction.
-    fn inverse_exponent() -> u64 {
-        F::RESCUE_ALPHA
-    }
+    fn inverse_exponent() -> u64;
 
     #[inline]
     /// The building block of a round in the slow, 'forward' direction.

--- a/src/nova/proof.rs
+++ b/src/nova/proof.rs
@@ -532,7 +532,7 @@ mod test {
     }
 
     fn test_nova_proof_aux<V: MinRootVDF<pallas::Scalar>>() {
-        use pasta_curves::arithmetic::Field;
+        use ff::Field;
 
         let mut rng = XorShiftRng::from_seed(TEST_SEED);
 


### PR DESCRIPTION
This PR updates to the latest pasta_curves. It depends on an update to Nova doing the same.

For now, there is a git dependency to my fork of the Nova update.

Once a new Nova release has been made, we can update `Cargo.toml` accordingly.